### PR TITLE
Implement dot notation and autocomplete

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ export default function Home() {
   );
 }
 
-const Wrapper = styled('main')`
+const Wrapper = styled.main`
   max-width: 38rem;
   margin: 0 auto;
   padding: 32px;
@@ -25,7 +25,7 @@ const Wrapper = styled('main')`
   border-radius: 8px;
 `;
 
-const Heading = styled('h1')`
+const Heading = styled.h1`
   font-size: 1.5rem;
   margin: 0;
   margin-bottom: 1em;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,7 +25,7 @@ const Wrapper = styled.main`
   border-radius: 8px;
 `;
 
-const Heading = styled.h1`
+const Heading = styled('h1')`
   font-size: 1.5rem;
   margin: 0;
   margin-bottom: 1em;

--- a/src/components/CountButton.js
+++ b/src/components/CountButton.js
@@ -15,7 +15,7 @@ export default function CountButton() {
 // Currently, this doesn't work, because `cache()` can't be used in
 // Client Components. It throws an error, and none of the styles get
 // created.
-const Button = styled('button')`
+const Button = styled.button`
   padding: 1rem 2rem;
   color: red;
   font-size: 1rem;

--- a/src/components/StaticButton.js
+++ b/src/components/StaticButton.js
@@ -5,7 +5,7 @@ export default function StaticButton() {
   return <Button>Static Button</Button>;
 }
 
-const Button = styled('button')`
+const Button = styled.button`
   display: block;
   padding: 1rem 2rem;
   border: none;

--- a/src/styled.js
+++ b/src/styled.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { cache } from './components/StyleRegistry';
 
 /**
- * @typedef {(css: string) => React.FunctionComponent<React.HTMLProps<HTMLElement>>} StyledFunction
- * @typedef {Record<keyof JSX.IntrinsicElements, StyledFunction>} StyledInterface
+ * @typedef {(css: TemplateStringsArray) => React.FunctionComponent<React.HTMLProps<HTMLElement>>} StyledFunction
+ * @typedef {Record<keyof JSX.IntrinsicElements, StyledFunction> & { (tag: keyof JSX.IntrinsicElements | React.ComponentType<any>): StyledFunction }} StyledInterface
  */
 
 /**

--- a/src/styled.js
+++ b/src/styled.js
@@ -1,25 +1,48 @@
 import React from 'react';
-
 import { cache } from './components/StyleRegistry';
 
-// TODO: Ideally, this API would use dot notation (styled.div) in
-// addition to function calls (styled('div')). We should be able to
-// use Proxies for this, like Framer Motion does.
-export default function styled(Tag) {
-  return (css) => {
-    return function StyledComponent(props) {
-      let collectedStyles = cache();
+/**
+ * @typedef {(css: string) => React.FunctionComponent<React.HTMLProps<HTMLElement>>} StyledFunction
+ * @typedef {Record<keyof JSX.IntrinsicElements, StyledFunction>} StyledInterface
+ */
 
-      // Instead of using the filename, I'm using the `useId` hook to
-      // generate a unique ID for each styled-component.
-      const id = React.useId().replace(/:/g, '');
-      const generatedClassName = `styled-${id}`;
+/**
+ * Creating a Proxy around the `styled` function.
+ * This allows us to intercept property accesses (like styled.div)
+ * and treat them as function calls (like styled('div')).
+ *
+ * @type {StyledInterface}
+ */
+const styled = new Proxy(
+  function (Tag) {
+    // The original styled function that creates a styled component
+    return (css) => {
+      return function StyledComponent(props) {
+        let collectedStyles = cache();
 
-      const styleContent = `.${generatedClassName} { ${css} }`;
+        // Using the `useId` hook to generate a unique ID for each styled-component.
+        const id = React.useId().replace(/:/g, "");
+        const generatedClassName = `styled-${id}`;
 
-      collectedStyles.push(styleContent);
+        const styleContent = `.${generatedClassName} { ${css} }`;
 
-      return <Tag className={generatedClassName} {...props} />;
+        collectedStyles.push(styleContent);
+
+        return <Tag className={generatedClassName} {...props} />;
+      };
     };
-  };
-}
+  },
+  {
+    get: function (target, prop) {
+      // Intercepting property access on the `styled` function.
+      if (typeof prop === 'string') {
+        // If the property is a string, call the original `styled` function with the property name as the tag.
+        return target(prop);
+      }
+      // Default behavior for other properties
+      return Reflect.get(target, prop);
+    },
+  }
+);
+
+export default styled;


### PR DESCRIPTION
## Description
This pull request brings enhancements to the `styled` function. Previously, it required the use of parentheses for component creation, as noted in the TODO comments. The new implementation transitions to a more intuitive and streamlined dot notation approach, aligning with `styled-components` development practices. It also introduces autocomplete features for HTML elements, aiming to improve the developer experience.

## Proposed Changes
- **Dot Notation Support**: Introduces dot notation for the `styled` function, aligning with `styled-components` practices. This allows syntax like `styled.div` instead of `styled('div')`, enhancing code readability and brevity.
- **Autocomplete for HTML Elements**: Adds autocomplete functionality for HTML elements within the `styled` function, enhancing coding efficiency and reducing the likelihood of errors. This feature supports both dot notation and the classic parentheses approach.
- **Refactoring of Existing Styled Components**: These changes have been reflected in the existing components, showcasing the new syntax in practice. The `Heading` component is still using the parentheses approach to show that both methods work as expected.

## More Information
While dot notation is the new star of the show, parentheses are still in the band. They'll be particularly handy when implementing styled components inheritance, which Josh explained pretty awesome in his course.

Feedback and suggestions are always welcome. If you have any thoughts or ideas on how we can further improve this implementation, please feel free to share them. Collaboration is key to making the codebase better!
