### PR TITLE
Add props interpolation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ export default function Home() {
   );
 }
 
-const Wrapper = styled('main')`
+const Wrapper = styled.main`
   max-width: 38rem;
   margin: 0 auto;
   padding: 32px;
@@ -25,7 +25,7 @@ const Wrapper = styled('main')`
   border-radius: 8px;
 `;
 
-const Heading = styled('h1')`
+const Heading = styled.h1`
   font-size: 1.5rem;
   margin: 0;
   margin-bottom: 1em;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,7 +25,7 @@ const Wrapper = styled.main`
   border-radius: 8px;
 `;
 
-const Heading = styled.h1`
+const Heading = styled('h1')`
   font-size: 1.5rem;
   margin: 0;
   margin-bottom: 1em;

--- a/src/components/CountButton.js
+++ b/src/components/CountButton.js
@@ -15,7 +15,7 @@ export default function CountButton() {
 // Currently, this doesn't work, because `cache()` can't be used in
 // Client Components. It throws an error, and none of the styles get
 // created.
-const Button = styled('button')`
+const Button = styled.button`
   padding: 1rem 2rem;
   color: red;
   font-size: 1rem;

--- a/src/components/StaticButton.js
+++ b/src/components/StaticButton.js
@@ -5,7 +5,7 @@ export default function StaticButton() {
   return <Button>Static Button</Button>;
 }
 
-const Button = styled('button')`
+const Button = styled.button`
   display: block;
   padding: 1rem 2rem;
   border: none;

--- a/src/components/StaticButton.js
+++ b/src/components/StaticButton.js
@@ -11,7 +11,7 @@ const Button = styled.button`
   border: none;
   border-radius: 4px;
   background: ${(props) =>
-    props.primary ? "hsl(270deg 100% 30%)" : "hsl(180deg 100% 30%)"};
+    props.primary ? 'hsl(270deg 100% 30%)' : 'hsl(180deg 100% 30%)'};
   color: white;
   font-size: 1rem;
   cursor: pointer;

--- a/src/components/StaticButton.js
+++ b/src/components/StaticButton.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '../styled.js';
 
 export default function StaticButton() {
-  return <Button>Static Button</Button>;
+  return <Button primary>Static Button</Button>;
 }
 
 const Button = styled.button`
@@ -10,7 +10,8 @@ const Button = styled.button`
   padding: 1rem 2rem;
   border: none;
   border-radius: 4px;
-  background: hsl(270deg 100% 30%);
+  background: ${(props) =>
+    props.primary ? "hsl(270deg 100% 30%)" : "hsl(180deg 100% 30%)"};
   color: white;
   font-size: 1rem;
   cursor: pointer;

--- a/src/styled.js
+++ b/src/styled.js
@@ -16,15 +16,21 @@ import { cache } from './components/StyleRegistry';
 const styled = new Proxy(
   function (Tag) {
     // The original styled function that creates a styled component
-    return (css) => {
+    return (templateStrings, ...interpolatedProps) => {
       return function StyledComponent(props) {
         let collectedStyles = cache();
+
+        // Concatenate the parts of the template string with the interpolated props.
+        const generatedCSS = templateStrings.reduce((acc, current, i) => {
+          const interpolatedValue = interpolatedProps[i]?.(props) || "";
+          return acc + current + interpolatedValue;
+        }, '');
 
         // Using the `useId` hook to generate a unique ID for each styled-component.
         const id = React.useId().replace(/:/g, "");
         const generatedClassName = `styled-${id}`;
 
-        const styleContent = `.${generatedClassName} { ${css} }`;
+        const styleContent = `.${generatedClassName} { ${generatedCSS} }`;
 
         collectedStyles.push(styleContent);
 

--- a/src/styled.js
+++ b/src/styled.js
@@ -22,12 +22,12 @@ const styled = new Proxy(
 
         // Concatenate the parts of the template string with the interpolated props.
         const generatedCSS = templateStrings.reduce((acc, current, i) => {
-          const interpolatedValue = interpolatedProps[i]?.(props) || "";
+          const interpolatedValue = interpolatedProps[i]?.(props) || '';
           return acc + current + interpolatedValue;
         }, '');
 
         // Using the `useId` hook to generate a unique ID for each styled-component.
-        const id = React.useId().replace(/:/g, "");
+        const id = React.useId().replace(/:/g, '');
         const generatedClassName = `styled-${id}`;
 
         const styleContent = `.${generatedClassName} { ${generatedCSS} }`;

--- a/src/styled.js
+++ b/src/styled.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { cache } from './components/StyleRegistry';
 
 /**
- * @typedef {(css: string) => React.FunctionComponent<React.HTMLProps<HTMLElement>>} StyledFunction
- * @typedef {Record<keyof JSX.IntrinsicElements, StyledFunction>} StyledInterface
+ * @typedef {(css: TemplateStringsArray) => React.FunctionComponent<React.HTMLProps<HTMLElement>>} StyledFunction
+ * @typedef {Record<keyof JSX.IntrinsicElements, StyledFunction> & { (tag: keyof JSX.IntrinsicElements | React.ComponentType<any>): StyledFunction }} StyledInterface
  */
 
 /**

--- a/src/styled.js
+++ b/src/styled.js
@@ -1,25 +1,48 @@
 import React from 'react';
-
 import { cache } from './components/StyleRegistry';
 
-// TODO: Ideally, this API would use dot notation (styled.div) in
-// addition to function calls (styled('div')). We should be able to
-// use Proxies for this, like Framer Motion does.
-export default function styled(Tag) {
-  return (css) => {
-    return function StyledComponent(props) {
-      let collectedStyles = cache();
+/**
+ * @typedef {(css: string) => React.FunctionComponent<React.HTMLProps<HTMLElement>>} StyledFunction
+ * @typedef {Record<keyof JSX.IntrinsicElements, StyledFunction>} StyledInterface
+ */
 
-      // Instead of using the filename, I'm using the `useId` hook to
-      // generate a unique ID for each styled-component.
-      const id = React.useId().replace(/:/g, '');
-      const generatedClassName = `styled-${id}`;
+/**
+ * Creating a Proxy around the `styled` function.
+ * This allows us to intercept property accesses (like styled.div)
+ * and treat them as function calls (like styled('div')).
+ *
+ * @type {StyledInterface}
+ */
+const styled = new Proxy(
+  function (Tag) {
+    // The original styled function that creates a styled component
+    return (css) => {
+      return function StyledComponent(props) {
+        let collectedStyles = cache();
 
-      const styleContent = `.${generatedClassName} { ${css} }`;
+        // Using the `useId` hook to generate a unique ID for each styled-component.
+        const id = React.useId().replace(/:/g, "");
+        const generatedClassName = `styled-${id}`;
 
-      collectedStyles.push(styleContent);
+        const styleContent = `.${generatedClassName} { ${css} }`;
 
-      return <Tag className={generatedClassName} {...props} />;
+        collectedStyles.push(styleContent);
+
+        return <Tag className={generatedClassName} {...props} />;
+      };
     };
-  };
-}
+  },
+  {
+    get: function (target, prop) {
+      // Intercepting property access on the `styled` function.
+      if (typeof prop === 'string') {
+        // If the property is a string, call the original `styled` function with the property name as the tag.
+        return target(prop);
+      }
+      // Default behavior for other properties
+      return Reflect.get(target, prop);
+    },
+  }
+);
+
+export default styled;


### PR DESCRIPTION
## Description
This pull request introduces props interpolation to the `styled` function, enhancing its capabilities to be more aligned with popular styling libraries like `styled-components`. It allows developers to interpolate props directly into their styled components, providing more dynamic and versatile styling options.

## Proposed Changes
- **Props Interpolation**: This pull request enables props interpolation within the `styled` function. You can now use template literals and interpolate props seamlessly into your styles, improving the flexibility of styled components. For example, you can style components based on their props like `background: ${props => props.primary ? "hsl(270deg 100% 30%)" : "hsl(180deg 100% 30%)"};`.

- **Updated Examples**: The existing `StaticButton` component has been updated to showcase the new props interpolation feature. It demonstrates how you can style components based on their props directly within the styled component definition.

## More Information
Props interpolation adds a powerful dimension to styling components, allowing for dynamic styles based on component props. Feedback and suggestions are highly encouraged. If you have any ideas or improvements to further enhance this feature, please share them. Collaboration is key to advancing this codebase!

## Why is it on draft?
This PR is based on #2, so it should be merged after that one (or I could merge it to that branch when approved).