### PR TITLE
Add styled components inheritance

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ export default function Home() {
   );
 }
 
-const Wrapper = styled('main')`
+const Wrapper = styled.main`
   max-width: 38rem;
   margin: 0 auto;
   padding: 32px;
@@ -25,7 +25,7 @@ const Wrapper = styled('main')`
   border-radius: 8px;
 `;
 
-const Heading = styled('h1')`
+const Heading = styled.h1`
   font-size: 1.5rem;
   margin: 0;
   margin-bottom: 1em;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import CountButton from '@/components/CountButton';
 import StaticButton from '@/components/StaticButton';
+import InheritanceDemo from '@/components/InheritanceDemo';
 import styled from '@/styled.js';
 
 export default function Home() {
@@ -13,6 +14,7 @@ export default function Home() {
       */}
       <CountButton />
       <StaticButton />
+      <InheritanceDemo />
     </Wrapper>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,7 +25,7 @@ const Wrapper = styled.main`
   border-radius: 8px;
 `;
 
-const Heading = styled.h1`
+const Heading = styled('h1')`
   font-size: 1.5rem;
   margin: 0;
   margin-bottom: 1em;

--- a/src/components/CountButton.js
+++ b/src/components/CountButton.js
@@ -15,7 +15,7 @@ export default function CountButton() {
 // Currently, this doesn't work, because `cache()` can't be used in
 // Client Components. It throws an error, and none of the styles get
 // created.
-const Button = styled('button')`
+const Button = styled.button`
   padding: 1rem 2rem;
   color: red;
   font-size: 1rem;

--- a/src/components/InheritanceDemo.js
+++ b/src/components/InheritanceDemo.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled from '../styled.js';
+
+export default function InheritanceDemo() {
+  return (
+    <Wrapper>
+      <ChildButton primary>Primary child Button</ChildButton>
+      <ChildButton>Not primary child Button</ChildButton>
+      <ParentButton primary>Primary parent Button</ParentButton>
+      <ParentButton>Not primary parent Button</ParentButton>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+const ParentButton = styled.button`
+  display: block;
+  padding: 1rem 2rem;
+  border: none;
+  border-radius: 4px;
+  background: ${(props) =>
+    props.primary ? 'hsl(270deg 100% 30%)' : 'hsl(100deg 100% 30%)'};
+  color: white;
+  font-size: 1rem;
+  cursor: pointer;
+`;
+
+const ChildButton = styled(ParentButton)`
+  border: 5px solid red;
+  color: black;
+  font-weight: 600;
+`;

--- a/src/components/StaticButton.js
+++ b/src/components/StaticButton.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '../styled.js';
 
 export default function StaticButton() {
-  return <Button primary>Static Button</Button>;
+  return <OtherButton>Static Button</OtherButton>;
 }
 
 const Button = styled.button`
@@ -10,9 +10,12 @@ const Button = styled.button`
   padding: 1rem 2rem;
   border: none;
   border-radius: 4px;
-  background: ${(props) =>
-    props.primary ? "hsl(270deg 100% 30%)" : "hsl(180deg 100% 30%)"};
+  background: hsl(270deg 100% 30%);
   color: white;
   font-size: 1rem;
   cursor: pointer;
+`;
+
+const OtherButton = styled(Button)`
+  color: red;
 `;

--- a/src/components/StaticButton.js
+++ b/src/components/StaticButton.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '../styled.js';
 
 export default function StaticButton() {
-  return <OtherButton>Static Button</OtherButton>;
+  return <Button primary>Static Button</Button>;
 }
 
 const Button = styled.button`
@@ -10,12 +10,8 @@ const Button = styled.button`
   padding: 1rem 2rem;
   border: none;
   border-radius: 4px;
-  background: hsl(270deg 100% 30%);
-  color: white;
+  background: ${(props) =>
+    props.primary ? 'hsl(270deg 100% 30%)' : 'hsl(180deg 100% 30%)'};  color: white;
   font-size: 1rem;
   cursor: pointer;
-`;
-
-const OtherButton = styled(Button)`
-  color: red;
 `;

--- a/src/components/StaticButton.js
+++ b/src/components/StaticButton.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '../styled.js';
 
 export default function StaticButton() {
-  return <Button>Static Button</Button>;
+  return <Button primary>Static Button</Button>;
 }
 
 const Button = styled.button`
@@ -10,7 +10,8 @@ const Button = styled.button`
   padding: 1rem 2rem;
   border: none;
   border-radius: 4px;
-  background: hsl(270deg 100% 30%);
+  background: ${(props) =>
+    props.primary ? 'hsl(270deg 100% 30%)' : 'hsl(180deg 100% 30%)'};
   color: white;
   font-size: 1rem;
   cursor: pointer;

--- a/src/components/StaticButton.js
+++ b/src/components/StaticButton.js
@@ -5,7 +5,7 @@ export default function StaticButton() {
   return <Button>Static Button</Button>;
 }
 
-const Button = styled('button')`
+const Button = styled.button`
   display: block;
   padding: 1rem 2rem;
   border: none;

--- a/src/components/StaticButton.js
+++ b/src/components/StaticButton.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '../styled.js';
 
 export default function StaticButton() {
-  return <Button>Static Button</Button>;
+  return <Button primary>Static Button</Button>;
 }
 
 const Button = styled.button`
@@ -10,7 +10,8 @@ const Button = styled.button`
   padding: 1rem 2rem;
   border: none;
   border-radius: 4px;
-  background: hsl(270deg 100% 30%);
+  background: ${(props) =>
+    props.primary ? "hsl(270deg 100% 30%)" : "hsl(180deg 100% 30%)"};
   color: white;
   font-size: 1rem;
   cursor: pointer;

--- a/src/components/StyleRegistry.js
+++ b/src/components/StyleRegistry.js
@@ -6,11 +6,24 @@ export const cache = React.cache(() => {
   return [];
 });
 
+const sortFn = (a, b) => {
+  const aClassCount = a.fullClassName.split(' ').length;
+  const bClassCount = b.fullClassName.split(' ').length;
+
+  if (aClassCount === bClassCount) {
+    // If they have the same class count, maintain the original order.
+    return 0;
+  } else {
+    // Sort by the number of classes in ascending order.
+    return aClassCount - bClassCount;
+  }
+}
+
 function StyleRegistry({ children }) {
   const collectedStyles = cache();
   const stylesMap = React.useMemo(
     () =>
-      collectedStyles.map(({ className, css }) => `.${className} { ${css} }`),
+      collectedStyles.sort(sortFn).map(({ className, css }) => `.${className} { ${css} }`),
     [collectedStyles]
   );
 

--- a/src/components/StyleRegistry.js
+++ b/src/components/StyleRegistry.js
@@ -8,7 +8,11 @@ export const cache = React.cache(() => {
 
 function StyleRegistry({ children }) {
   const collectedStyles = cache();
-  const stylesMap = collectedStyles.map(({ styles }) => styles);
+  const stylesMap = React.useMemo(
+    () =>
+      collectedStyles.map(({ className, css }) => `.${className} { ${css} }`),
+    [collectedStyles]
+  );
 
   return (
     <>

--- a/src/components/StyleRegistry.js
+++ b/src/components/StyleRegistry.js
@@ -8,10 +8,11 @@ export const cache = React.cache(() => {
 
 function StyleRegistry({ children }) {
   const collectedStyles = cache();
+  const stylesMap = collectedStyles.map(({ styles }) => styles);
 
   return (
     <>
-      <StyleInserter styles={collectedStyles} />
+      <StyleInserter styles={stylesMap} />
       {children}
     </>
   );

--- a/src/styled.js
+++ b/src/styled.js
@@ -16,15 +16,21 @@ import { cache } from './components/StyleRegistry';
 const styled = new Proxy(
   function (Tag) {
     // The original styled function that creates a styled component
-    return (css) => {
+    return (templateStrings, ...interpolatedProps) => {
       return function StyledComponent(props) {
         let collectedStyles = cache();
+
+        // Concatenate the parts of the template string with the interpolated props.
+        const generatedCSS = templateStrings.reduce((acc, current, i) => {
+          const interpolatedValue = interpolatedProps[i]?.(props) || "";
+          return acc + current + interpolatedValue;
+        }, '');
 
         // Using the `useId` hook to generate a unique ID for each styled-component.
         const id = React.useId().replace(/:/g, "");
         const generatedClassName = `styled-${id}`;
 
-        const styleContent = `.${generatedClassName} { ${css} }`;
+        const styleContent = `.${generatedClassName} { ${generatedCSS} }`;
 
         collectedStyles.push(styleContent);
 

--- a/src/styled.js
+++ b/src/styled.js
@@ -16,15 +16,21 @@ import { cache } from './components/StyleRegistry';
 const styled = new Proxy(
   function (Tag) {
     // The original styled function that creates a styled component
-    return (css) => {
+    return (templateStrings, ...interpolatedProps) => {
       return function StyledComponent(props) {
         let collectedStyles = cache();
 
+        // Concatenate the parts of the template string with the interpolated props.
+        const generatedCSS = templateStrings.reduce((acc, current, i) => {
+          const interpolatedValue = interpolatedProps[i]?.(props) || '';
+          return acc + current + interpolatedValue;
+        }, '');
+
         // Using the `useId` hook to generate a unique ID for each styled-component.
-        const id = React.useId().replace(/:/g, "");
+        const id = React.useId().replace(/:/g, '');
         const generatedClassName = `styled-${id}`;
 
-        const styleContent = `.${generatedClassName} { ${css} }`;
+        const styleContent = `.${generatedClassName} { ${generatedCSS} }`;
 
         collectedStyles.push(styleContent);
 

--- a/src/styled.js
+++ b/src/styled.js
@@ -49,7 +49,10 @@ const styled = new Proxy(
             return <Tag className={currentStyle.fullClassName} {...props} />;
 
           // If they have the same styles but different props, use the parent class name, and the current style one
-          return <Tag className={`${parentClassName} ${currentStyle.className}`} {...props} />;
+          const className = parentClassName
+            ? `${parentClassName} ${currentStyle.className}`
+            : currentStyle.className;
+          return <Tag className={className} {...props} />;
         }
 
         collectedStyles.push({

--- a/src/styled.js
+++ b/src/styled.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { cache } from './components/StyleRegistry';
 
 /**
- * @typedef {(css: string) => React.FunctionComponent<React.HTMLProps<HTMLElement>>} StyledFunction
- * @typedef {Record<keyof JSX.IntrinsicElements, StyledFunction>} StyledInterface
+ * @typedef {(css: TemplateStringsArray) => React.FunctionComponent<React.HTMLProps<HTMLElement>>} StyledFunction
+ * @typedef {Record<keyof JSX.IntrinsicElements, StyledFunction> & { (tag: keyof JSX.IntrinsicElements | React.ComponentType<any>): StyledFunction }} StyledInterface
  */
 
 /**

--- a/src/styled.js
+++ b/src/styled.js
@@ -1,25 +1,48 @@
 import React from 'react';
-
 import { cache } from './components/StyleRegistry';
 
-// TODO: Ideally, this API would use dot notation (styled.div) in
-// addition to function calls (styled('div')). We should be able to
-// use Proxies for this, like Framer Motion does.
-export default function styled(Tag) {
-  return (css) => {
-    return function StyledComponent(props) {
-      let collectedStyles = cache();
+/**
+ * @typedef {(css: string) => React.FunctionComponent<React.HTMLProps<HTMLElement>>} StyledFunction
+ * @typedef {Record<keyof JSX.IntrinsicElements, StyledFunction>} StyledInterface
+ */
 
-      // Instead of using the filename, I'm using the `useId` hook to
-      // generate a unique ID for each styled-component.
-      const id = React.useId().replace(/:/g, '');
-      const generatedClassName = `styled-${id}`;
+/**
+ * Creating a Proxy around the `styled` function.
+ * This allows us to intercept property accesses (like styled.div)
+ * and treat them as function calls (like styled('div')).
+ *
+ * @type {StyledInterface}
+ */
+const styled = new Proxy(
+  function (Tag) {
+    // The original styled function that creates a styled component
+    return (css) => {
+      return function StyledComponent(props) {
+        let collectedStyles = cache();
 
-      const styleContent = `.${generatedClassName} { ${css} }`;
+        // Using the `useId` hook to generate a unique ID for each styled-component.
+        const id = React.useId().replace(/:/g, "");
+        const generatedClassName = `styled-${id}`;
 
-      collectedStyles.push(styleContent);
+        const styleContent = `.${generatedClassName} { ${css} }`;
 
-      return <Tag className={generatedClassName} {...props} />;
+        collectedStyles.push(styleContent);
+
+        return <Tag className={generatedClassName} {...props} />;
+      };
     };
-  };
-}
+  },
+  {
+    get: function (target, prop) {
+      // Intercepting property access on the `styled` function.
+      if (typeof prop === 'string') {
+        // If the property is a string, call the original `styled` function with the property name as the tag.
+        return target(prop);
+      }
+      // Default behavior for other properties
+      return Reflect.get(target, prop);
+    },
+  }
+);
+
+export default styled;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,16 @@
+export function areObjectsEqual(obj1, obj2) {
+  const keys1 = Object.keys(obj1);
+  const keys2 = Object.keys(obj2);
+
+  if (keys1.length !== keys2.length) {
+    return false;
+  }
+
+  for (const key of keys1) {
+    if (obj1[key] !== obj2[key]) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Description
This pull request introduces inheritance support to the `styled` function, expanding its capabilities and providing developers with a powerful tool for creating styled components that inherit styles from other components. It builds upon the existing functionality and extends it to support component inheritance seamlessly.

## Proposed Changes
- **Styled Components Inheritance**: With this update, the `styled` function now supports inheritance, allowing you to create styled components that inherit styles from other components.
  - Forward parent classes to children.
  - Forward props to parents.
  - Update `StyleRegistry`
  - Reorder CSS classes definition to ensure overwrites as expected, and not the other way around.
- **Improved Code Reusability**: Styled component inheritance promotes code reusability by enabling you to reuse and extend styles from existing components. This can lead to more maintainable and efficient codebases.

## More Information
It would be beneficial to reuse both classes and add a third one with just the changes, such as the background based on props. However, this may be a task for future optimization. I think this is a great starting point.

## Why is it on draft?
This PR is in progress and it's also based on #3, so it should be merged after that one (or I could merge it to that branch when approved).