### PR TITLE
make client component support work

### DIFF
--- a/src/components/StaticButton.js
+++ b/src/components/StaticButton.js
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 import styled from '../styled.js';
 

--- a/src/components/StyleRegistry.js
+++ b/src/components/StyleRegistry.js
@@ -1,20 +1,14 @@
 import React from 'react';
 
-import StyleInserter from './StyleInserter';
+import StyleRegistryClient from './StyleRegistryClient';
+import StyleRegistryServer from './StyleRegistryServer';
 
-export const cache = React.cache(() => {
-  return [];
-});
-
-function StyleRegistry({ children }) {
-  const collectedStyles = cache();
-
+export default function StyleRegistry({ children }) {
   return (
     <>
-      <StyleInserter styles={collectedStyles} />
+      <StyleRegistryServer />
+      <StyleRegistryClient />
       {children}
     </>
   );
 }
-
-export default StyleRegistry;

--- a/src/components/StyleRegistryClient.js
+++ b/src/components/StyleRegistryClient.js
@@ -1,0 +1,9 @@
+"use client";
+import { cache } from './cache';
+import StyleInserter from './StyleInserter';
+
+export default function StyleRegistryClient() {
+  const collectedStyles = cache();
+
+  return <StyleInserter styles={collectedStyles} />;
+}

--- a/src/components/StyleRegistryServer.js
+++ b/src/components/StyleRegistryServer.js
@@ -1,0 +1,8 @@
+import { cache } from './cache';
+import StyleInserter from './StyleInserter';
+
+export default function StyleRegistryServer() {
+  const collectedStyles = cache();
+
+  return <StyleInserter styles={collectedStyles} />;
+}

--- a/src/components/cache.js
+++ b/src/components/cache.js
@@ -1,0 +1,25 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import * as React from 'react';
+
+export const useServerCache = React.cache(() => []);
+
+let clientContext;
+
+function getClientCache() {
+  if (!clientContext) {
+    clientContext = React.createContext([]);
+  }
+
+  return clientContext;
+}
+
+export function cache() {
+  try {
+    // React Server Component
+    return useServerCache();
+  } catch (e) {
+    // React Client Component
+    const clientContext = getClientCache();
+    return React.useContext(clientContext);
+  }
+}

--- a/src/styled.js
+++ b/src/styled.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { cache } from './components/StyleRegistry';
+import { cache } from './components/cache';
 
 // TODO: Ideally, this API would use dot notation (styled.div) in
 // addition to function calls (styled('div')). We should be able to


### PR DESCRIPTION
I was curious about the comment in https://github.com/joshwcomeau/dream-css-tool/issues/6:

![Screenshot 2024-02-09 at 01 13 14](https://github.com/joshwcomeau/dream-css-tool/assets/3165635/fbac833f-87f0-4635-9e33-0ff9cfa1b416)

It looks like it can be solved by using two contexts, one client context (goes into the client bundle), and one server context (stays inside the Node.js bundle). The output:

![Screenshot 2024-02-09 at 01 19 25](https://github.com/joshwcomeau/dream-css-tool/assets/3165635/7d298ab7-0088-461c-9952-f524cad605ca)
